### PR TITLE
Fix parseQueryPFs

### DIFF
--- a/src/Titan/Parser.hs
+++ b/src/Titan/Parser.hs
@@ -12,7 +12,6 @@ import Data.Attoparsec.ByteString
       option,
       sepBy',
       try,
-      many',
       endOfInput,
       Parser )
 import Data.Attoparsec.ByteString.Char8 (endOfLine)

--- a/src/Titan/Parser.hs
+++ b/src/Titan/Parser.hs
@@ -12,6 +12,7 @@ import Data.Attoparsec.ByteString
       option,
       sepBy',
       try,
+      many',
       endOfInput,
       Parser )
 import Data.Attoparsec.ByteString.Char8 (endOfLine)
@@ -92,10 +93,10 @@ parseQueryFlag :: Parser Text
 parseQueryFlag = text
 
 parseQueryPFs :: Parser (QueryFlags, QueryParams)
-parseQueryPFs = qmark *> (partitionEithers <$> sepQueries)
+parseQueryPFs = qmark *> (partitionEithers <$> sep)
 
-sepQueries :: Parser [Either Text (Text,Text)]
-sepQueries = sepBy' p ampersand
+sep :: Parser [Either Text (Text,Text)]
+sep = sepBy' p ampersand
   where
     p = try (Left <$> (parseQueryFlag <* endOfInput)) <|> try (Right <$> parseQueryParam)
 


### PR DESCRIPTION
It had a bug. It can't parse qp correctly multi times.
I encountered it when tried `add` endpoint.